### PR TITLE
Add rswag to project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,8 @@ gem 'cancancan'
 gem 'bcrypt', '~> 3.1', '>= 3.1.18'
 
 gem 'jwt'
+
+# add rswag
+gem 'rswag'
+
+gem 'swagger_ui_engine'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     erubi (1.12.0)
+    ffi (1.15.5-x64-mingw-ucrt)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -115,6 +116,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    json-schema (3.0.0)
+      addressable (>= 2.8)
     jwt (2.7.0)
     loofah (2.19.1)
       crass (~> 1.0.2)
@@ -210,6 +213,20 @@ GEM
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
     rspec-support (3.12.0)
+    rswag (2.8.0)
+      rswag-api (= 2.8.0)
+      rswag-specs (= 2.8.0)
+      rswag-ui (= 2.8.0)
+    rswag-api (2.8.0)
+      railties (>= 3.1, < 7.1)
+    rswag-specs (2.8.0)
+      activesupport (>= 3.1, < 7.1)
+      json-schema (>= 2.2, < 4.0)
+      railties (>= 3.1, < 7.1)
+      rspec-core (>= 2.14)
+    rswag-ui (2.8.0)
+      actionpack (>= 3.1, < 7.1)
+      railties (>= 3.1, < 7.1)
     rubocop (1.48.1)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -224,6 +241,16 @@ GEM
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (4.8.1)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -237,7 +264,11 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
+    swagger_ui_engine (1.1.2)
+      rails (>= 4.2)
+      sass-rails
     thor (1.2.1)
+    tilt (2.1.0)
     timeout (0.3.2)
     turbo-rails (1.4.0)
       actionpack (>= 6.0.0)
@@ -287,10 +318,12 @@ DEPENDENCIES
   rails (~> 7.0.4, >= 7.0.4.2)
   rails-controller-testing
   rspec-rails
+  rswag
   rubocop (>= 1.0, < 2.0)
   selenium-webdriver
   sprockets-rails
   stimulus-rails
+  swagger_ui_engine
   turbo-rails
   tzinfo-data
   web-console

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,15 @@
+Rswag::Api.configure do |c|
+
+    # Specify a root folder where Swagger JSON files are located
+    # This is used by the Swagger middleware to serve requests for API descriptions
+    # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+    # that it's configured to generate files in the same folder
+    c.swagger_root = Rails.root.to_s + '/swagger'
+  
+    # Inject a lambda function to alter the returned Swagger prior to serialization
+    # The function will have access to the rack env for the current request
+    # For example, you could leverage this to dynamically assign the "host" property
+    #
+    #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+  end
+  

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,17 @@
+Rswag::Ui.configure do |c|
+
+    # List the Swagger endpoints that you want to be documented through the
+    # swagger-ui. The first parameter is the path (absolute or relative to the UI
+    # host) to the corresponding endpoint and the second is a title that will be
+    # displayed in the document selector.
+    # NOTE: If you're using rspec-api to expose Swagger files
+    # (under swagger_root) as JSON or YAML endpoints, then the list below should
+    # correspond to the relative paths for those endpoints.
+  
+    c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+  
+    # Add Basic Auth in case your API is private
+    # c.basic_auth_enabled = true
+    # c.basic_auth_credentials 'username', 'password'
+  end
+  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,7 @@ Rails.application.routes.draw do
   end
   end
 
+  mount SwaggerUiEngine::Engine, at: '/swagger'
+
   root 'users#index'
 end

--- a/spec/fixtures/posts.yml
+++ b/spec/fixtures/posts.yml
@@ -1,0 +1,4 @@
+post1:
+  title: 'Hello from form'
+  text: 'Hello'
+  author: paulina

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,0 +1,5 @@
+paulina:
+  name: 'Jerome'
+  photo: 'https://unsplash.com/photos/XUdIi04ohps'
+  bio: 'Jay'
+  email: '187jjay187@gmail.com'

--- a/spec/requests/api/v1/comments_spec.rb
+++ b/spec/requests/api/v1/comments_spec.rb
@@ -1,7 +1,33 @@
-# require 'rails_helper'
+require 'swagger_helper'
 
-# RSpec.describe "Api::V1::Comments", type: :request do
-#   describe "GET /index" do
-#     pending "add some examples (or delete) #{__FILE__}"
-#   end
-# end
+RSpec.describe 'Api::V1::Comments', type: :request do
+  fixtures :users, :posts # load the users fixture
+  describe 'GET /api/v1/users/:user_id/posts/:post_id/comments' do
+    it 'returns status code 200' do
+      user = users(:paulina) # use the paulina fixture
+      post = posts(:post1) # use the post_1 fixture
+      get api_v1_user_post_comments_path(user.id, post.id)
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'POST /api/v1/users/:user_id/posts/:post_id/comments' do
+    fixtures :users, :posts
+    it 'checks if comment has been added' do
+      user = users(:paulina) # use the paulina fixture
+      post = posts(:post1) # use the post_1 fixture
+      valid_attributes = {
+        comment: {
+          post: posts(:post1),
+          author: users(:paulina),
+          text: 'Hello there'
+        }
+      }
+      post api_v1_user_post_comments_path(user.id, post.id), params: valid_attributes
+      puts response.body
+      expect(response).to have_http_status(201)
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['text']).to eq('Hello there')
+    end
+  end
+end

--- a/spec/requests/api/v1/posts_spec.rb
+++ b/spec/requests/api/v1/posts_spec.rb
@@ -1,7 +1,12 @@
-# require 'rails_helper'
+require 'swagger_helper'
 
-# RSpec.describe "Api::V1::Posts", type: :request do
-#   describe "GET /index" do
-#     pending "add some examples (or delete) #{__FILE__}"
-#   end
-# end
+RSpec.describe 'Api::V1::Posts', type: :request do
+  fixtures :users # load the users fixture
+  describe 'GET /api/v1/users/:user_id/posts/' do
+    it 'returns status code 200' do
+      user = users(:paulina) # use the paulina fixture
+      get api_v1_user_posts_path(user)
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+# Specify a root folder where Swagger JSON files are generated
+# NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+# to ensure that it's configured to serve Swagger from the same folder
+
+# Define one or more Swagger documents and provide global metadata for each one
+# When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+# be generated at the provided relative path under swagger_root
+# By default, the operations defined in spec files are added to the first
+# document below. You can override this behavior by adding a swagger_doc tag to the
+# the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+
+# rubocop:disable Metrics/BlockLength
+RSpec.configure do |config|
+  config.swagger_root = Rails.root.join('swagger').to_s
+
+  config.swagger_docs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {
+        '/api/v1/users/{user_id}/posts': {
+          get: {
+            summary: 'List all posts for a user',
+            parameters: [
+              {
+                name: 'user_id',
+                in: 'path',
+                description: 'ID of the user',
+                required: true,
+                schema: {
+                  type: 'integer'
+                }
+              }
+            ],
+            responses: {
+              '200': {
+                description: 'A list of posts',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          id: { type: 'integer' },
+                          title: { type: 'string' },
+                          body: { type: 'string' }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        '/api/v1/users/{user_id}/posts/{post_id}/comments': {
+          get: {
+            summary: 'List all comments for a user\'s post',
+            parameters: [
+              {
+                name: 'user_id',
+                in: 'path',
+                description: 'ID of the user',
+                required: true,
+                schema: {
+                  type: 'integer'
+                }
+              },
+              {
+                name: 'post_id',
+                in: 'path',
+                description: 'ID of the post',
+                required: true,
+                schema: {
+                  type: 'integer'
+                }
+              }
+            ],
+            responses: {
+              '200': {
+                description: 'A list of comments',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          id: { type: 'integer' },
+                          body: { type: 'string' },
+                          created_at: { type: 'string', format: 'date-time' },
+                          user: {
+                            type: 'object',
+                            properties: {
+                              id: { type: 'integer' },
+                              name: { type: 'string' }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'localhost:3000'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  config.swagger_format = :yaml
+end
+# rubocop:enable Metrics/BlockLength
+
+# Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+# The swagger_docs configuration option has the filename including format in
+# the key, this may want to be changed to avoid putting yaml in json files.
+# Defaults to json. Accepts ':json' and ':yaml'.

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,123 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/api/v1/users/{user_id}/posts":
+    get:
+      summary: List all posts for a user
+      parameters:
+      - name: user_id
+        in: path
+        description: ID of the user
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: A list of posts
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    title:
+                      type: string
+                    body:
+                      type: string
+  "/api/v1/users/{user_id}/posts/{post_id}/comments":
+    get:
+      summary: List all comments for a user's post
+      parameters:
+      - name: user_id
+        in: path
+        description: ID of the user
+        required: true
+        schema:
+          type: integer
+      - name: post_id
+        in: path
+        description: ID of the post
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: A list of comments
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    body:
+                      type: string
+                    created_at:
+                      type: string
+                      format: date-time
+                    user:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        name:
+                          type: string
+  post:
+    summary: Add a comment to a post
+    parameters:
+    - name: user_id
+      in: path
+      description: ID of the user
+      required: true
+      schema:
+        type: integer
+    - name: post_id
+      in: path
+      description: ID of the post
+      required: true
+      schema:
+        type: integer
+    - name: text
+      in: body
+      description: The comment to add
+      required: true
+      schema:
+        type: object
+        properties:
+          body:
+            type: string
+    responses:
+      '201':
+        description: The created comment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: integer
+                body:
+                  type: string
+                created_at:
+                  type: string
+                  format: datetime
+                user:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+servers:
+- url: https://{defaultHost}
+  variables:
+    defaultHost:
+      default: localhost:3000


### PR DESCRIPTION
# Blog app - API documentation

## Exercise
In this exercise, you will add documentation for your API endpoints using [rswag](https://github.com/rswag/rswag). Remember that this involves writing the specs that will then be turned into actual documentation and accessible in [swagger-ui](https://github.com/swagger-api/swagger-ui) at `/api-docs`
